### PR TITLE
Add in testing and code coverage starter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: node_js
+
+node_js:
+  - stable
+
+script: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## HyperList
 
+[![Build Status](https://travis-ci.org/tbranyen/hyperlist.svg?branch=testing)](https://travis-ci.org/tbranyen/hyperlist)
+
 This is a simple component that can be dropped into any JavaScript application
 and provide a virtual scrolling area that is highly performant and lightweight.
 With zero dependencies and well under 200 lines of code sans comments, it is

--- a/dist/hyperlist.js
+++ b/dist/hyperlist.js
@@ -28,28 +28,34 @@ var _lastRepaint = Symbol('lastRepaint');
 var _getRow = Symbol('getRow');
 var _getScrollPosition = Symbol('getScrollPosition');
 
+// Create two elements, the wrapper is `1px` tall and is transparent and
+// positioned at the top of the page. Inside that is an element that gets set
+// to 1 billion pixels. Then reads the max height the browser can calculate.
+var wrapper = document.createElement('div');
+var fixture = document.createElement('div');
+
+// As said above, these values get set to put the fixture elements into the
+// right visual state.
+wrapper.style = 'position: absolute; height: 1px; opacity: 0;';
+fixture.style = 'height: 1000000000px;';
+
+// Add the fixture into the wrapper element.
+wrapper.appendChild(fixture);
+
+// Apply to the page, the values won't kick in unless this is attached.
+document.body.appendChild(wrapper);
+
+// Get the maximum element height in pixels.
+var maxElementHeight = fixture.offsetHeight;
+
+// Remove the element immediately after reading the value.
+document.body.removeChild(wrapper);
+
 var HyperList = function () {
   _createClass(HyperList, null, [{
     key: 'create',
     value: function create(element, userProvidedConfig) {
       return new HyperList(element, userProvidedConfig);
-    }
-  }, {
-    key: 'maxElementHeight',
-    get: function get() {
-      var wrapper = document.createElement('div');
-      var fixture = document.createElement('div');
-
-      wrapper.style = 'position: absolute; height: 1px; opacity: 0;';
-      fixture.style = 'height: 1000000000px;';
-
-      wrapper.appendChild(fixture);
-
-      document.body.appendChild(wrapper);
-      var retVal = fixture.offsetHeight;
-      document.body.removeChild(wrapper);
-
-      return retVal;
     }
   }]);
 
@@ -146,7 +152,6 @@ var HyperList = function () {
       element.setAttribute('style', '\n      width: ' + config.width + ';\n      height: ' + config.height + ';\n      overflow: auto;\n      position: relative;\n      padding: 0;\n    ');
 
       var scrollerHeight = config.itemHeight * config.total;
-      var maxElementHeight = HyperList.maxElementHeight;
 
       if (scrollerHeight > maxElementHeight) {
         console.warn(['HyperList: The maximum element height ' + maxElementHeight + 'px has', 'been exceeded; please reduce your item height.'].join());

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,25 +18,32 @@ const _lastRepaint = Symbol('lastRepaint');
 const _getRow = Symbol('getRow');
 const _getScrollPosition = Symbol('getScrollPosition');
 
+// Create two elements, the wrapper is `1px` tall and is transparent and
+// positioned at the top of the page. Inside that is an element that gets set
+// to 1 billion pixels. Then reads the max height the browser can calculate.
+const wrapper = document.createElement('div');
+const fixture = document.createElement('div');
+
+// As said above, these values get set to put the fixture elements into the
+// right visual state.
+wrapper.style = 'position: absolute; height: 1px; opacity: 0;';
+fixture.style = 'height: 1000000000px;';
+
+// Add the fixture into the wrapper element.
+wrapper.appendChild(fixture);
+
+// Apply to the page, the values won't kick in unless this is attached.
+document.body.appendChild(wrapper);
+
+// Get the maximum element height in pixels.
+const maxElementHeight = fixture.offsetHeight;
+
+// Remove the element immediately after reading the value.
+document.body.removeChild(wrapper);
+
 export default class HyperList {
   static create(element, userProvidedConfig) {
     return new HyperList(element, userProvidedConfig);
-  }
-
-  static get maxElementHeight() {
-    const wrapper = document.createElement('div');
-    const fixture = document.createElement('div');
-
-    wrapper.style = 'position: absolute; height: 1px; opacity: 0;';
-    fixture.style = 'height: 1000000000px;';
-
-    wrapper.appendChild(fixture);
-
-    document.body.appendChild(wrapper);
-    const retVal = fixture.offsetHeight;
-    document.body.removeChild(wrapper);
-
-    return retVal;
   }
 
   constructor(element, userProvidedConfig=defaultConfig) {
@@ -132,7 +139,6 @@ export default class HyperList {
     `);
 
     const scrollerHeight = config.itemHeight * config.total;
-    const maxElementHeight = HyperList.maxElementHeight;
 
     if (scrollerHeight > maxElementHeight) {
       console.warn([

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "faker": "^3.1.0",
     "istanbul": "^1.0.0-alpha.2",
     "mocha": "^2.4.5",
-    "stringdom": "^0.2.0",
+    "stringdom": "jugglinmike/stringdom#f42ad65227fc4e5a1d120ae432c7ec4eaf6aa11b",
     "watchify": "^3.7.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -5,10 +5,14 @@
   "devDependencies": {
     "babel-core": "^6.6.0",
     "babel-preset-es2015": "^6.6.0",
+    "babel-register": "^6.8.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
     "derequire": "^2.0.3",
     "faker": "^3.1.0",
+    "istanbul": "^1.0.0-alpha.2",
+    "mocha": "^2.4.5",
+    "stringdom": "^0.2.0",
     "watchify": "^3.7.0"
   },
   "keywords": [
@@ -31,7 +35,8 @@
   },
   "scripts": {
     "build": "browserify -t [ babelify --presets [ es2015 ] ] -s HyperList lib/index.js | derequire > dist/hyperlist.js",
-    "watch": "watchify -t [ babelify --presets [ es2015 ] ] -s HyperList lib/index.js -o 'derequire > dist/hyperlist.js' -v"
+    "watch": "watchify -t [ babelify --presets [ es2015 ] ] -s HyperList lib/index.js -o 'derequire > dist/hyperlist.js' -v",
+    "test": "istanbul cover node_modules/mocha/bin/_mocha --report html -- --compilers js:babel-register --colors --reporter spec test/"
   },
   "author": "Tim Branyen (@tbranyen)",
   "contributors": [

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -1,0 +1,8 @@
+const Document = require('stringdom');
+
+// Set up a pretend DOM for the tests.
+global.document = new Document();
+global.document.body = document.createElement('body');
+
+// Ensure requestAnimationFrame is a thing.
+global.requestAnimationFrame = fn => setTimeout(fn, 100);

--- a/test/api.js
+++ b/test/api.js
@@ -1,0 +1,46 @@
+require('./_setup');
+
+const assert = require('assert');
+const HyperList = require('../');
+
+describe('API', () => {
+  var fixture = null;
+
+  beforeEach(() => {
+    fixture = document.createElement('div');
+  });
+
+  it('requires being called with default in ES5', () => {
+    assert.notEqual(typeof HyperList, 'function');
+    assert.equal(typeof HyperList.default, 'function');
+  });
+
+  it('can be initialized with new', () => {
+    var actual = new HyperList.default(fixture, {
+      generate() {},
+      total: 0
+    });
+
+    assert.ok(actual instanceof HyperList.default);
+  });
+
+  it('is not easy to access private members', () => {
+    var actual = new HyperList.default(fixture, {
+      generate() {},
+      total: 0
+    });
+
+    assert.equal(actual.config, undefined);
+    assert.equal(actual[Symbol('config')], undefined);
+  });
+
+  it('is not easy to access private members', () => {
+    var actual = new HyperList.default(fixture, {
+      generate() {},
+      total: 0
+    });
+
+    assert.equal(actual.config, undefined);
+    assert.equal(actual[Symbol('config')], undefined);
+  });
+});


### PR DESCRIPTION
I've added in Mocha and Istanbul alpha for ES6. I needed to bring in babel-register as well. Since we don't do much with the DOM I used Stringdom from @jugglinmike to simulate the DOM node operations.

- Also made `maxElementHeight` a fixed value that gets determined on load

I'll bring Travis CI coverage in before merging.