### PR TITLE
Tweak compute scroll height by using a median

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -267,7 +267,10 @@ export default class HyperList {
     const total = config.total
 
     let from = config.reverse ? this._getReverseFrom(scrollTop) : this._getFrom(scrollTop) - 1
-    from = from < 0 ? 0 : from
+
+    if (from < 0 || from - this._cachedItemsLen < 0) {
+      from = 0
+    }
 
     if (this._lastFrom === from) {
       return false
@@ -276,7 +279,10 @@ export default class HyperList {
     this._lastFrom = from
 
     let to = from + this._cachedItemsLen
-    to = to > total ? total : to
+
+    if (to > total || to + this._cachedItemsLen > total) {
+      to = total
+    }
 
     // Append all the new rows in a document fragment that we will later append
     // to the parent node
@@ -339,13 +345,17 @@ export default class HyperList {
       height: `${scrollHeight}px`
     })
 
-    const averageHeight = scrollHeight / total
-    const containerHeight = this._element.innerHeight ? this._element.innerHeight : this._containerHeight
+    // Calculate the height median
+    const sortedItemHeights = this._itemHeights.slice(0).sort((a, b) => a - b)
+    const middle = Math.floor(total / 2)
+    const averageHeight = total % 2 === 0 ? (sortedItemHeights[middle] + sortedItemHeights[middle - 1]) / 2 : sortedItemHeights[middle]
+
+    const containerHeight = this._element.clientHeight ? this._element.clientHeight : this._containerHeight
     this._screenItemsLen = Math.ceil(containerHeight / averageHeight)
     this._containerHeight = containerHeight
 
     // Cache 3 times the number of items that fit in the container viewport.
-    this._cachedItemsLen = this._screenItemsLen * 3
+    this._cachedItemsLen = Math.max(this._cachedItemsLen || 0, this._screenItemsLen * 3)
     this._averageHeight = averageHeight
 
     if (config.reverse) {


### PR DESCRIPTION
I noted that when you have really different heights, there is a possibility that `_screenItemsLen` resolves to `1` (then `3`) and therefore you might be missing elements at the top/bottom (position start `0` / position end `total`). 

To resolve this issue I've changed the height computation to use a median instead of a basic average. Also, we will keep the highest value of `_screenItemsLen` to avoid setting it less then required (really depends on the height of the elements currently shown).

This may increase the number of rendered elements, but it has almost no performance overhead, and it's more important to guarantee that all the elements are shown.