### PR TITLE
Body scrollContainer

### DIFF
--- a/dist/hyperlist.js
+++ b/dist/hyperlist.js
@@ -105,7 +105,8 @@ var HyperList = function () {
         return;
       }
 
-      if (!lastRepaint || Math.abs(scrollTop - lastRepaint) > _this._averageHeight) {
+      var diff = lastRepaint ? scrollTop - lastRepaint : 0;
+      if (!lastRepaint || diff < 0 || diff > _this._averageHeight) {
         var rendered = _this._renderChunk();
 
         _this._lastRepaint = scrollTop;
@@ -195,22 +196,27 @@ var HyperList = function () {
         }
       }
 
-      // Decorate the container element with styles that will match
-      // the user supplied configuration.
-      var elementStyle = {
-        width: '' + config.width,
-        height: '' + config.height,
-        overflow: 'auto',
-        position: 'relative'
-      };
-
-      HyperList.mergeStyle(element, elementStyle);
-
+      var scrollContainer = config.scrollContainer;
       var scrollerHeight = config.itemHeight * config.total;
       var maxElementHeight = this._maxElementHeight;
 
       if (scrollerHeight > maxElementHeight) {
         console.warn(['HyperList: The maximum element height', maxElementHeight + 'px has', 'been exceeded; please reduce your item height.'].join(' '));
+      }
+
+      // Decorate the container element with styles that will match
+      // the user supplied configuration.
+      var elementStyle = {
+        width: '' + config.width,
+        height: scrollContainer ? scrollerHeight + 'px' : '' + config.height,
+        overflow: scrollContainer ? 'none' : 'auto',
+        position: 'relative'
+      };
+
+      HyperList.mergeStyle(element, elementStyle);
+
+      if (scrollContainer) {
+        HyperList.mergeStyle(config.scrollContainer, { overflow: 'auto' });
       }
 
       var scrollerStyle = (_scrollerStyle = {
@@ -343,7 +349,7 @@ var HyperList = function () {
   }, {
     key: '_computePositions',
     value: function _computePositions() {
-      var from = arguments.length <= 0 || arguments[0] === undefined ? 1 : arguments[0];
+      var from = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 1;
 
       var config = this._config;
       var total = config.total;
@@ -391,7 +397,8 @@ var HyperList = function () {
       var averageHeight = total % 2 === 0 ? (sortedItemHeights[middle] + sortedItemHeights[middle - 1]) / 2 : sortedItemHeights[middle];
 
       var clientProp = isHoriz ? 'clientWidth' : 'clientHeight';
-      var containerHeight = this._element[clientProp] ? this._element[clientProp] : this._containerSize;
+      var element = config.scrollContainer ? config.scrollContainer : this._element;
+      var containerHeight = element[clientProp] ? element[clientProp] : this._containerSize;
       this._screenItemsLen = Math.ceil(containerHeight / averageHeight);
       this._containerSize = containerHeight;
 

--- a/examples/body-scroll.html
+++ b/examples/body-scroll.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+  <title>Hyper List Demo</title>
+
+  <style>
+    body, html {
+      padding: 0;
+      margin: 0;
+      height: 100%;
+      width: 100%;
+      min-height: 100%;
+      min-width: 100%;
+      text-align: center;
+    }
+    body {
+      overflow: hidden;
+    }
+
+    @media
+    only screen and (-webkit-min-device-pixel-ratio : 1.5),
+    only screen and (min-device-pixel-ratio : 1.5) {
+      .container {
+        width: 100%;
+        height: 100%;
+        min-height: 100%;
+      }
+    }
+
+    .vrow {
+      width: 100%;
+      height: 30px;
+      max-height: 30px;
+      color: #000;
+      margin: 0;
+      padding-top: 10px;
+      padding-bottom: 10px;
+    }
+
+    .vrow p {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin: 0;
+      color: #5b5b5b;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Hyperlist</h1>
+</header>
+<div id="list">
+</div>
+<footer>
+  github
+</footer>
+
+<script type="text/javascript" src="../dist/hyperlist.js"></script>
+<script>
+  var container = document.getElementById('list');
+  var config = {
+    height: window.innerHeight,
+    itemHeight: 50,
+    total: 100000,
+    // Set to true to put into 'chat mode'.
+    reverse: false,
+    scrollerTagName: 'div',
+    scrollContainer: document.body,
+    overrideScrollPosition() {
+      return (window.pageYOffset - (container.offsetTop - document.body.offsetTop)) || 0
+    },
+    generate(row) {
+      var el = document.createElement("div");
+      el.innerHTML = "<p>ITEM " + row + "</p>";
+      return el;
+    }
+  };
+
+  var list = HyperList.create(container, config);
+
+  window.onresize = e => {
+    config.height = window.innerHeight;
+    list.refresh(container, config);
+  };
+
+  container.classList.add("container");
+</script>
+</body>
+</html>

--- a/lib/index.js
+++ b/lib/index.js
@@ -166,17 +166,7 @@ export default class HyperList {
       }
     }
 
-    // Decorate the container element with styles that will match
-    // the user supplied configuration.
-    const elementStyle = {
-      width: `${config.width}`,
-      height: `${config.height}`,
-      overflow: 'auto',
-      position: 'relative'
-    }
-
-    HyperList.mergeStyle(element, elementStyle)
-
+    const scrollContainer = config.scrollContainer
     const scrollerHeight = config.itemHeight * config.total
     const maxElementHeight = this._maxElementHeight
 
@@ -185,6 +175,21 @@ export default class HyperList {
         'HyperList: The maximum element height', maxElementHeight + 'px has',
         'been exceeded; please reduce your item height.'
       ].join(' '))
+    }
+
+    // Decorate the container element with styles that will match
+    // the user supplied configuration.
+    const elementStyle = {
+      width: `${config.width}`,
+      height: scrollContainer ? `${scrollerHeight}px` : `${config.height}`,
+      overflow: scrollContainer ? 'none' : 'auto',
+      position: 'relative'
+    }
+
+    HyperList.mergeStyle(element, elementStyle)
+
+    if (scrollContainer) {
+      HyperList.mergeStyle(config.scrollContainer, {overflow: 'auto'})
     }
 
     const scrollerStyle = {
@@ -356,7 +361,8 @@ export default class HyperList {
     const averageHeight = total % 2 === 0 ? (sortedItemHeights[middle] + sortedItemHeights[middle - 1]) / 2 : sortedItemHeights[middle]
 
     const clientProp = isHoriz ? 'clientWidth' : 'clientHeight'
-    const containerHeight = this._element[clientProp] ? this._element[clientProp] : this._containerSize
+    const element = config.scrollContainer ? config.scrollContainer : this._element
+    const containerHeight = element[clientProp] ? element[clientProp] : this._containerSize
     this._screenItemsLen = Math.ceil(containerHeight / averageHeight)
     this._containerSize = containerHeight
 


### PR DESCRIPTION
This in an interesting case where you want to scroll `body` (for example) but where the list still shows in its own container. 

This gives you the ability to have header/footer elements that are not fixed with a virtual scroll. 

I'm not sure yet if the `overrideScrollPosition` should be implicit with a `scrollContainer` though. 

Note that `overrideScrollPosition` is not enough because the height of the container will need to be `scrollerHeight` so that a `footer` (for example) could stay in a relative position.