### PR TITLE
Use element.classList if available to add the rowClassName to the item

### DIFF
--- a/dist/hyperlist.js
+++ b/dist/hyperlist.js
@@ -16,11 +16,18 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 var defaultConfig = {
   width: '100%',
   height: '100%'
+
+  // Check for valid number.
+};var isNumber = function isNumber(input) {
+  return Number(input) === Number(input);
 };
 
-// Check for valid number.
-var isNumber = function isNumber(input) {
-  return Number(input) === Number(input);
+// Add a class to an element.
+var addClass = 'classList' in document.documentElement ? function (element, className) {
+  element.classList.add(className);
+} : function (element, className) {
+  var oldClass = element.getAttribute('class') || '';
+  element.setAttribute('class', oldClass + ' ' + className);
 };
 
 /**
@@ -105,7 +112,8 @@ var HyperList = function () {
         return;
       }
 
-      if (!lastRepaint || Math.abs(scrollTop - lastRepaint) > _this._averageHeight) {
+      var diff = lastRepaint ? scrollTop - lastRepaint : 0;
+      if (!lastRepaint || diff < 0 || diff > _this._averageHeight) {
         var rendered = _this._renderChunk();
 
         _this._lastRepaint = scrollTop;
@@ -266,8 +274,7 @@ var HyperList = function () {
         throw new Error('Generator did not return a DOM Node for index: ' + i);
       }
 
-      var oldClass = item.getAttribute('class') || '';
-      item.setAttribute('class', oldClass + ' ' + (config.rowClassName || 'vrow'));
+      addClass(item, config.rowClassName || 'vrow');
 
       var top = this._itemPositions[i];
 
@@ -343,7 +350,7 @@ var HyperList = function () {
   }, {
     key: '_computePositions',
     value: function _computePositions() {
-      var from = arguments.length <= 0 || arguments[0] === undefined ? 1 : arguments[0];
+      var from = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 1;
 
       var config = this._config;
       var total = config.total;

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,16 @@ const defaultConfig = {
 // Check for valid number.
 const isNumber = input => Number(input) === Number(input)
 
+// Add a class to an element.
+const addClass = 'classList' in document.documentElement
+  ? (element, className) => {
+    element.classList.add(className)
+  }
+  : (element, className) => {
+    const oldClass = element.getAttribute('class') || ''
+    element.setAttribute('class', `${oldClass} ${className}`)
+  }
+
 /**
  * Creates a HyperList instance that virtually scrolls very large amounts of
  * data effortlessly.
@@ -241,8 +251,7 @@ export default class HyperList {
       throw new Error(`Generator did not return a DOM Node for index: ${i}`)
     }
 
-    const oldClass = item.getAttribute('class') || ''
-    item.setAttribute('class', `${oldClass} ${config.rowClassName || 'vrow'}`)
+    addClass(item, config.rowClassName || 'vrow')
 
     const top = this._itemPositions[i]
 


### PR DESCRIPTION
This is a minor change to use Element.classList.add DOM method if its available. This takes care of preserving existing class names and not duplicating the name if its already in the classlist.
The main reason I need this is I noticed that when reusing elements in the config.generate function, the class name ('vrow') is just appended. The element ended up with class=' vrow vrow vrow', with the duplicated list growing each time generate was called.
Note that if classList is not available, the fallback is identical to the current behaviour. Not sure if its worth it to do proper string manipulation to make sure class name is not repeated.