### PR TITLE
Add support for container padding

### DIFF
--- a/dist/hyperlist.js
+++ b/dist/hyperlist.js
@@ -1,4 +1,4 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.HyperList = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.HyperList = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(_dereq_,module,exports){
 'use strict';
 
 // Default configuration.
@@ -238,6 +238,10 @@ var HyperList = function () {
         element.appendChild(scroller);
       }
 
+      var padding = this._computeScrollPadding();
+      this._scrollPaddingBottom = padding.bottom;
+      this._scrollPaddingTop = padding.top;
+
       // Set the scroller instance.
       this._scroller = scroller;
       this._scrollHeight = this._computeScrollHeight();
@@ -266,7 +270,7 @@ var HyperList = function () {
         item = item.element;
 
         // The height isn't the same as predicted, compute positions again
-        if (height !== this._itemHeights) {
+        if (height !== this._itemHeights[i]) {
           this._itemHeights[i] = height;
           this._computePositions(i);
           this._scrollHeight = this._computeScrollHeight(i);
@@ -281,7 +285,7 @@ var HyperList = function () {
 
       addClass(item, config.rowClassName || 'vrow');
 
-      var top = this._itemPositions[i];
+      var top = this._itemPositions[i] + this._scrollPaddingTop;
 
       HyperList.mergeStyle(item, _defineProperty({
         position: 'absolute'
@@ -388,11 +392,12 @@ var HyperList = function () {
       var total = config.total;
       var scrollHeight = this._itemHeights.reduce(function (a, b) {
         return a + b;
-      }, 0);
+      }, 0) + this._scrollPaddingBottom + this._scrollPaddingTop;
 
       HyperList.mergeStyle(this._scroller, (_HyperList$mergeStyle2 = {
         opacity: 0,
-        position: 'absolute'
+        position: 'absolute',
+        top: '0px'
       }, _defineProperty(_HyperList$mergeStyle2, isHoriz ? 'height' : 'width', '1px'), _defineProperty(_HyperList$mergeStyle2, isHoriz ? 'width' : 'height', scrollHeight + 'px'), _HyperList$mergeStyle2));
 
       // Calculate the height median
@@ -423,6 +428,41 @@ var HyperList = function () {
       }
 
       return scrollHeight;
+    }
+  }, {
+    key: '_computeScrollPadding',
+    value: function _computeScrollPadding() {
+      var config = this._config;
+      var isHoriz = Boolean(config.horizontal);
+      var isReverse = config.reverse;
+      var styles = window.getComputedStyle(this._element);
+
+      var padding = function padding(location) {
+        var cssValue = styles.getPropertyValue('padding-' + location);
+        return parseInt(cssValue, 10) || 0;
+      };
+
+      if (isHoriz && isReverse) {
+        return {
+          bottom: padding('left'),
+          top: padding('right')
+        };
+      } else if (isHoriz) {
+        return {
+          bottom: padding('right'),
+          top: padding('left')
+        };
+      } else if (isReverse) {
+        return {
+          bottom: padding('top'),
+          top: padding('bottom')
+        };
+      } else {
+        return {
+          bottom: padding('bottom'),
+          top: padding('top')
+        };
+      }
     }
   }, {
     key: '_getFrom',

--- a/lib/index.js
+++ b/lib/index.js
@@ -216,6 +216,10 @@ export default class HyperList {
       element.appendChild(scroller)
     }
 
+    const padding = this._computeScrollPadding()
+    this._scrollPaddingBottom = padding.bottom
+    this._scrollPaddingTop = padding.top
+
     // Set the scroller instance.
     this._scroller = scroller
     this._scrollHeight = this._computeScrollHeight()
@@ -258,7 +262,7 @@ export default class HyperList {
 
     addClass(item, config.rowClassName || 'vrow')
 
-    const top = this._itemPositions[i]
+    const top = this._itemPositions[i] + this._scrollPaddingTop
 
     HyperList.mergeStyle(item, {
       position: 'absolute',
@@ -355,11 +359,12 @@ export default class HyperList {
     const config = this._config
     const isHoriz = Boolean(config.horizontal)
     const total = config.total
-    const scrollHeight = this._itemHeights.reduce((a, b) => a + b, 0)
+    const scrollHeight = this._itemHeights.reduce((a, b) => a + b, 0) + this._scrollPaddingBottom + this._scrollPaddingTop
 
     HyperList.mergeStyle(this._scroller, {
       opacity: 0,
       position: 'absolute',
+      top: '0px',
       [isHoriz ? 'height' : 'width']: '1px',
       [isHoriz ? 'width' : 'height']: `${scrollHeight}px`
     })
@@ -390,6 +395,40 @@ export default class HyperList {
     }
 
     return scrollHeight
+  }
+
+  _computeScrollPadding () {
+    const config = this._config
+    const isHoriz = Boolean(config.horizontal)
+    const isReverse = config.reverse
+    const styles = window.getComputedStyle(this._element)
+
+    const padding = location => {
+      const cssValue = styles.getPropertyValue(`padding-${location}`)
+      return parseInt(cssValue, 10) || 0
+    }
+
+    if (isHoriz && isReverse) {
+      return {
+        bottom: padding('left'),
+        top: padding('right')
+      }
+    } else if (isHoriz) {
+      return {
+        bottom: padding('right'),
+        top: padding('left')
+      }
+    } else if (isReverse) {
+      return {
+        bottom: padding('top'),
+        top: padding('bottom')
+      }
+    } else {
+      return {
+        bottom: padding('bottom'),
+        top: padding('top')
+      }
+    }
   }
 
   _getFrom (scrollTop) {

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -12,3 +12,8 @@ global.document.createComment = function () {
 // Ensure (request|cancel)AnimationFrame is a thing.
 window.requestAnimationFrame = fn => setTimeout(fn, 10)
 window.cancelAnimationFrame = timeout => clearTimeout(timeout)
+
+// Ensure getComputedStyle is a thing.
+window.getComputedStyle = () => ({
+  getPropertyValue: () => '0px'
+})

--- a/test/react.js
+++ b/test/react.js
@@ -54,7 +54,7 @@ describe('React', function () {
 
       const actual = renderedString
 
-      const expected = '<div style="width:100%;height:5px;overflow:auto;position:relative;" data-reactroot="" data-reactid="1" data-react-checksum="803780303"><div style="opacity:0;position:absolute;width:1px;height:3px;" data-reactid="2"></div><div style="opacity:0;position:absolute;width:1px;height:3px;" data-reactid="3"></div><span style="position:absolute;top:0px;" class=" vrow" data-reactid="4"></span><span style="position:absolute;top:1px;" class=" vrow" data-reactid="5">1</span><span style="position:absolute;top:2px;" class=" vrow" data-reactid="6">2</span></div>'
+      const expected = '<div style="width:100%;height:5px;overflow:auto;position:relative;" data-reactroot="" data-reactid="1" data-react-checksum="332446863"><div style="opacity:0;position:absolute;width:1px;height:3px;top:0px;" data-reactid="2"></div><div style="opacity:0;position:absolute;width:1px;height:3px;top:0px;" data-reactid="3"></div><span style="position:absolute;top:0px;" class=" vrow" data-reactid="4"></span><span style="position:absolute;top:1px;" class=" vrow" data-reactid="5">1</span><span style="position:absolute;top:2px;" class=" vrow" data-reactid="6">2</span></div>'
 
       assert.equal(actual, expected)
       done()

--- a/test/reverse.js
+++ b/test/reverse.js
@@ -43,7 +43,7 @@ describe('Reverse feature', function () {
 
       applyPatch (element, fragment) {
         childNodes = fragment.map(childNode => {
-          if (!childNode.style.top) {
+          if (!childNode.style.top || childNode.nodeName === 'tr') {
             return false
           }
 


### PR DESCRIPTION
* Padding is computed, which supports values with `em` and other units as they are automatically converted to `px`
* Top/Bottom or left/right padding is added to the sizer ("scroller")
* Top/Left padding (which precedes the first item) is added to each item's _style position_, but not the scroll position, thereby retaining the padding values when using `scrollTo` with `_itemPositions`. For example, scrolling to item `0` would have otherwise never reached the the beginning (`0px`).
* Some tests were updated because now the scroller has a `top` CSS value.