### PR TITLE
listen to scroll evt instead of non-stop rAF

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,8 +83,6 @@ export default class HyperList {
       const scrollTop = this._getScrollPosition()
       const lastRepaint = this._lastRepaint
 
-      this._renderAnimationFrame = window.requestAnimationFrame(render)
-
       if (scrollTop === lastRepaint) {
         return
       }
@@ -102,6 +100,7 @@ export default class HyperList {
     }
 
     render()
+    this._element.addEventListener('scroll', () => window.requestAnimationFrame(render))
   }
 
   destroy () {


### PR DESCRIPTION
non-stop rAF takes 12% CPU (according to a quick CPU profile) even when when not scrolling