### PR TITLE
optimized removing childnodes during render

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -329,7 +329,7 @@ export default class HyperList {
       return config.applyPatch(element, fragment)
     }
 
-    element.innerHTML = ''
+    while (element.firstChild) element.lastChild.remove();
     element.appendChild(fragment)
   }
 


### PR DESCRIPTION
Added a better solution than innerHTML = '' for removing the child nodes. Possible fix for #64